### PR TITLE
Refactor into generic function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function stable(count, fn, val) {
 
 	for (var i = 1; i < count; i++) {
 		current = fn();
-		
+
 		if (current !== first) {
 			return val ? current : false;
 		}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function stable(count, fn, val) {
+function stable(val, count, fn) {
 	if (fn === undefined) {
 		fn = count;
 		count = 1000;
@@ -21,10 +21,5 @@ function stable(count, fn, val) {
 	return val ? first : true;
 }
 
-module.exports = function (count, fn) {
-	return stable(count, fn, false);
-};
-
-module.exports.val = function (count, fn) {
-	return stable(count, fn, true);
-};
+module.exports = stable.bind(null, false);
+module.exports.val = stable.bind(null, true);

--- a/index.js
+++ b/index.js
@@ -1,23 +1,6 @@
 'use strict';
 
-module.exports = function (count, fn) {
-	if (fn === undefined) {
-		fn = count;
-		count = 1000;
-	}
-
-	var first = fn();
-
-	for (var i = 1; i < count; i++) {
-		if (fn() !== first) {
-			return false;
-		}
-	}
-
-	return true;
-};
-
-module.exports.val = function (count, fn) {
+function stable(count, fn, val) {
 	if (fn === undefined) {
 		fn = count;
 		count = 1000;
@@ -28,11 +11,20 @@ module.exports.val = function (count, fn) {
 
 	for (var i = 1; i < count; i++) {
 		current = fn();
-
+		
 		if (current !== first) {
-			return current;
+			return val ? current : false;
 		}
+
 	}
 
-	return first;
+	return val ? first : true;
+}
+
+module.exports = function (count, fn) {
+	return stable(count, fn, false);
+};
+
+module.exports.val = function (count, fn) {
+	return stable(count, fn, true);
 };


### PR DESCRIPTION
The two functions `module.exports` and `module.exports.val` were nearly identical--good candidates for a refactor. The boolean `val` for "value" in the `stable` function should be true if a value is desired for the output and false if a boolean is desired.
